### PR TITLE
Split off a seperate thread to handle grid updates at regular intervals

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2,7 +2,6 @@
 name = "conway_rs"
 version = "0.0.1"
 dependencies = [
- "clock_ticks 0.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "glium 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "glutin 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -31,14 +30,6 @@ dependencies = [
  "num 0.1.24 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-serialize 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "clock_ticks"
-version = "0.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "libc 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,5 @@ authors = ["Cam Jackson <camjackson89@gmail.com>"]
 
 [dependencies]
 rand = "*"
-clock_ticks = "*"
 glium = "*"
 glutin = "*"


### PR DESCRIPTION
By syncing the main thread to vsync, and updating the grid on a background thread (using a mutex to keep things thread safe), the grid can update at a different rate than the display.
